### PR TITLE
Workflow update from uat

### DIFF
--- a/EMEP/batch_script_templates/batch_emep_europe_template.sh
+++ b/EMEP/batch_script_templates/batch_emep_europe_template.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: apache-2.0
 
-#SBATCH -t 0-2
+#SBATCH -t 0-6
 #SBATCH -p hpcpool
 #SBATCH -A hpc-dt-targ
 #SBATCH -N 4

--- a/EMEP/batch_script_templates/batch_emep_uk_3km_template.sh
+++ b/EMEP/batch_script_templates/batch_emep_uk_3km_template.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: apache-2.0
 
-#SBATCH -t 1-0
+#SBATCH -t 2-12
 #SBATCH -p hpcpool
 #SBATCH -A hpc-dt-targ
-#SBATCH -N 4
-#SBATCH -n 128
+#SBATCH -N 5
+#SBATCH -n 160
 #SBATCH -J EMEP-UK3-%%JOBID%%
 
 module load compilers/gcc/8.2.0
@@ -55,5 +55,5 @@ link_met_data ${WRF_3KM_PATH}
 
 # run EMEP for 3km UK grid
 cd ${WORK_PATH_3KM}
-mpiexec --mca -np 128 ${EMEP_EXEC}
+mpiexec --mca -np 160 ${EMEP_EXEC}
 

--- a/EMEP/batch_script_templates/batch_emep_uk_45km_template.sh
+++ b/EMEP/batch_script_templates/batch_emep_uk_45km_template.sh
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: apache-2.0
 
-#SBATCH -t 1-0
-#SBATCH -p multicore
-#SBATCH -n 36
+#SBATCH -t 0-12
+#SBATCH -p multicore_small
+#SBATCH -n 32
 #SBATCH -J EMEP-UK45-%%JOBID%%
 
 module load compilers/gcc/8.2.0
@@ -53,6 +53,6 @@ link_met_data ${WRF_45KM_PATH}
 
 # run EMEP for 45km UK grid
 cd ${WORK_PATH_45KM}
-mpiexec --mca -np 36 ${EMEP_EXEC}
+mpiexec --mca -np 32 ${EMEP_EXEC}
 
 

--- a/ERA5/ERA5_download_scripts/batch_download_template.sh
+++ b/ERA5/ERA5_download_scripts/batch_download_template.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: apache-2.0
 
-#SBATCH -t 0-6
+#SBATCH -t 0-12
 #SBATCH -p serial
 #SBATCH -J ERA5-%%JOBID%%
 

--- a/PostProc/Data_Extraction/batch_extract_template.sh
+++ b/PostProc/Data_Extraction/batch_extract_template.sh
@@ -13,6 +13,10 @@ conda activate wrf-python
 
 CWD=%%POSTPROCDIR%%
 
+WRFDIR=%%WRFDIR%%
+EMEPDIR=%%EMEPDIR%%
+OUTPUTDIR=%%OUTDIR%%
+
 STARTYEAR=%%YRST%%
 STARTMONTH=%%MONST%%
 STARTDAY=%%DAYST%%
@@ -21,11 +25,17 @@ ENDYEAR=%%YREND%%
 ENDMONTH=%%MONEND%%
 ENDDAY=%%DAYEND%%
 
-WRFDIR=%%WRFDIR%%
-EMEPDIR=%%EMEPDIR%%
-OUTPUTDIR=%%OUTDIR%%
+start_sec=$(date -d "${STARTYEAR}-${STARTMONTH}-${STARTDAY}" +%s)
+end_sec=$(date -d "${ENDYEAR}-${ENDMONTH}-${ENDDAY}" +%s)
 
+current_sec=$start_sec
 
-python data_extraction.py --startyear $STARTYEAR --startmonth $STARTMONTH --startday $STARTDAY \
-						--endyear $ENDYEAR --endmonth $ENDMONTH --endday $ENDDAY \
-						--wrfdir $WRFDIR --emepdir $EMEPDIR --outdir $OUTPUTDIR
+while (( current_sec <= end_sec )); do
+	YEAR=$(date -d "@$current_sec" +%Y)
+	MONTH=$(date -d "@$current_sec" +%m)
+	DAY=$(date -d "@$current_sec" +%d)
+	python data_extraction.py --startyear $YEAR --startmonth $MONTH --startday $DAY \
+                                  --endyear $YEAR --endmonth $MONTH --endday $DAY \
+                                  --wrfdir $WRFDIR --emepdir $EMEPDIR --outdir $OUTPUTDIR
+	current_sec=$(( current_sec + 86400 ))
+done

--- a/WRF/batch_script_templates/batch_wrf_outer_uk_template.sh
+++ b/WRF/batch_script_templates/batch_wrf_outer_uk_template.sh
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: apache-2.0
 
-#SBATCH -t 1-6
-#SBATCH -p multicore
-#SBATCH -n 36
+#SBATCH -t 0-12
+#SBATCH -p multicore_small
+#SBATCH -n 25
 #SBATCH -J WRF-OUTERUK-%%JOBID%%
 
 module load apps/gcc/wrf/4.5
@@ -33,4 +33,4 @@ ln -s ${CWD}/${REAL_NAME}/wrflowinp_d02 .
 
 # run the domains with different numbers of processes (due to differing domain sizes)
 rm rsl.error.* rsl.out.*
-time mpirun -np 36 wrf.exe
+time mpirun -np 25 wrf.exe


### PR DESCRIPTION
## Issue Description

User testing has highlighted some issues with the workflow. Main issues:
- `multicore` queue isn't universally available
- an OOM error occurs when using the python data extraction script for more than a couple of days of output

### What does this PR do?
Changes in this PR:
- Switch from `multicore` to `multicore_small`, and adapt cores and wallclock appropriately
- Add date range loop to the bash logic for data extraction, avoiding the OOM error for the python script (as this is called per day)
